### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.3.0
 description: |
   A pure Crystal Implementation of the BSON Specification.
 
-crystal: 0.35.0
+crystal: ">= 0.35.0, < 2.0.0"
 
 authors:
   - elbywan <elbywan@hotmail.com>


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.