### PR TITLE
update hash ext to allow multiple values that are BSON serializable

### DIFF
--- a/src/bson/ext/array.cr
+++ b/src/bson/ext/array.cr
@@ -4,16 +4,38 @@ class Array(T)
     {% begin %}
     {% types = T.union_types %}
 
+    {% if types.select(&.<=(Hash)).size > 1 %}
+    {% raise "Unable to deserialize #{@type.id}. Can only have one Hash value type." %}
+    {% end %}
+
+    {% if types.select(&.<=(Array)).size > 1 %}
+    {% raise "Unable to deserialize #{@type.id}. Can only have one Array value type." %}
+    {% end %}
+
     arr = self.new
 
-    bson.each do |_, v|
-      case v
+    bson.each do |(_, v, code, _)|
+      case {v, code}
+      {% htyp = types.find(&.<=(Hash)) %}
+      {% if htyp %}
+      when {BSON, BSON::Element::Document}
+        arr << {{ htyp }}.from_bson(v)
+      {% end %}
+
+      {% atyp = types.find(&.<=(Array)) %}
+      {% if atyp %}
+      when {BSON, BSON::Element::Array}
+        arr << {{ atyp }}.from_bson(v)
+      {% end %}
+
       {% for typ in types %}
-        {% if typ <= BSON::Serializable || typ.class.has_method? :from_bson %}
-        when BSON
+        {% if typ <= Hash || typ <= Array %}
+
+        {% elsif typ <= BSON::Serializable || typ.class.has_method? :from_bson %}
+        when {BSON, _}
           arr << {{ typ }}.from_bson(v)
         {% else %}
-        when {{ typ }}
+        when { {{ typ }}, _}
           arr << v.as({{ typ }})
         {% end %}
       {% end %}

--- a/src/bson/ext/hash.cr
+++ b/src/bson/ext/hash.cr
@@ -15,7 +15,7 @@ class Hash(K, V)
 
     hash = self.new
 
-    bson.each do |(k, v, code, binary_subtype)|
+    bson.each do |(k, v, code, _)|
       case {v, code}
 
       {% htyp = types.find(&.<=(Hash)) %}
@@ -43,7 +43,7 @@ class Hash(K, V)
         {% end %}
       {% end %}
       else
-        raise Exception.new "Unable to deserialize key '#{k}' for hash '#{{{@type.stringify}}}'."
+        raise Exception.new "Unable to deserialize key '#{k}' for hash '{{@type.id}}'."
       end
     end
 

--- a/src/bson/ext/hash.cr
+++ b/src/bson/ext/hash.cr
@@ -11,7 +11,7 @@ class Hash(K, V)
       case v
       {% for typ in types %}
         {% if typ <= BSON::Serializable || typ.class.has_method? :from_bson %}
-        when BSON
+        when {{ typ }}
           hash[k] = {{ typ }}.from_bson(v)
         {% else %}
         when {{ typ }}

--- a/src/bson/ext/hash.cr
+++ b/src/bson/ext/hash.cr
@@ -5,16 +5,40 @@ class Hash(K, V)
     {% begin %}
     {% types = V.union_types %}
 
+    {% if types.select(&.<=(Hash)).size > 1 %}
+    {% raise "Unable to deserialize #{@type.id}. Can only have one Hash value type." %}
+    {% end %}
+
+    {% if types.select(&.<=(Array)).size > 1 %}
+    {% raise "Unable to deserialize #{@type.id}. Can only have one Array value type." %}
+    {% end %}
+
     hash = self.new
 
-    bson.each do |k, v|
-      case v
-      {% for typ in types %}
-        {% if typ <= BSON::Serializable || typ.class.has_method? :from_bson %}
-        when {{ typ }}
+    bson.each do |(k, v, code, binary_subtype)|
+      case {v, code}
+
+      {% htyp = types.find(&.<=(Hash)) %}
+      {% if htyp %}
+      when {BSON, BSON::Element::Document}
+        hash[k] = {{ htyp }}.from_bson(v)
+      {% end %}
+
+      {% atyp = types.find(&.<=(Array)) %}
+      {% if atyp %}
+      when {BSON, BSON::Element::Array}
+        hash[k] = {{ atyp }}.from_bson(v)
+      {% end %}
+
+      {% for typ in types.uniq %}
+        {% if typ <= Hash || typ <= Array %}
+
+        {% elsif (typ <= BSON::Serializable || typ.class.has_method? :from_bson) %}
+        when { BSON, _ }
           hash[k] = {{ typ }}.from_bson(v)
+
         {% else %}
-        when {{ typ }}
+        when { {{ typ }}, _ }
           hash[k] = v.as({{typ}})
         {% end %}
       {% end %}
@@ -24,7 +48,6 @@ class Hash(K, V)
     end
 
     hash
-
     {% end %}
   end
 end


### PR DESCRIPTION
update hash ext to allow multiple values that are BSON serializable

The following error is thrown when a hash has multiple value types that are BSON serializable:

```
Error: duplicate when BSON in case
```

For example if a hash is defined as `Hash(String, Int32 | Float64 | String | Array(String) | Hash(String, String | Array(String)) | Bool)` is used, the `Array(String)` and `Hash(String, String | Array(String))` create duplicate when blocks in the macro.

This commit simply changes the `BSON` to `{{typ}}` in the when case.

---

```txt
There was a problem expanding macro 'macro_4710705456'

Called macro defined in lib/bson/src/bson/ext/hash.cr:5:5

 5 | {% begin %}

Which expanded to:

 >  1 |
 >  2 |
 >  3 |
 >  4 |     hash = self.new
 >  5 |
 >  6 |     bson.each do |k, v|
 >  7 |       case v
 >  8 |
 >  9 |
 > 10 |         when BSON
 > 11 |           hash[k] = Array(String).from_bson(v)
 > 12 |
 > 13 |
 > 14 |
 > 15 |         when Bool
 > 16 |           hash[k] = v.as(Bool)
 > 17 |
 > 18 |
 > 19 |
 > 20 |         when Float64
 > 21 |           hash[k] = v.as(Float64)
 > 22 |
 > 23 |
 > 24 |
 > 25 |         when BSON
 > 26 |           hash[k] = Hash(String, Array(String) | String).from_bson(v)
 > 27 |
 > 28 |
 > 29 |
 > 30 |         when Int32
 > 31 |           hash[k] = v.as(Int32)
 > 32 |
 > 33 |
 > 34 |
 > 35 |         when String
 > 36 |           hash[k] = v.as(String)
 > 37 |
 > 38 |
 > 39 |       else
 > 40 |         raise Exception.new "Unable to deserialize key '#{k}' for hash '#{"Hash(String, Array(String) | Bool | Float64 | Hash(String, Array(String) | String) | Int32 | String)"}'."
 > 41 |       end
 > 42 |     end
 > 43 |
 > 44 |     hash
 > 45 |
 > 46 |
Error: duplicate when BSON in case
```
